### PR TITLE
Small changes required for deployment to web

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -148,6 +148,7 @@ int main(int argc, char * argv[]) throw(...)
 
 
 	// Test tiling
+#ifdef _DEBUG
 	startWatch = std::chrono::system_clock::now();
 	wangTiling tiling = tileSet.give_stochastic_tiling(4, 3);
 	stopWatch = std::chrono::system_clock::now();
@@ -162,7 +163,7 @@ int main(int argc, char * argv[]) throw(...)
 	currentTime = std::chrono::system_clock::to_time_t(stopWatch);
 	std::cout << std::put_time(std::localtime(&currentTime), "%T") << ": Tiling image generated in " << timeInterval.count() << " s." << std::endl;
 	tiling.save_tiling_BMP(outputTilingImage);
-
+#endif
 
 	allStopWatch = std::chrono::system_clock::now();
 	timeInterval = stopWatch - startWatch;

--- a/main.cpp
+++ b/main.cpp
@@ -296,7 +296,7 @@ int main(int argc, char * argv[]) throw(...)
 
 
 	// Load tiles
-	if (!wtfOnly) {
+	if (!wtfOnly || useRefImg) {
 		startWatch = std::chrono::system_clock::now();
 		try {
 			tileSet.load_tiles_BMP(inputFolder, tileStencil, tileSuffix);

--- a/wangTiling.cpp
+++ b/wangTiling.cpp
@@ -50,7 +50,7 @@ void wangTiling::save_tiling_WTF(std::string outFile)
 	catch (std::ios_base::failure& inErr) {
 		std::cerr << "The requested output file cannot be created. System error: " << inErr.what() << std::endl;
 	}
-	for (int iTy = 0; iTy < nTy; iTy++) {
+	for (int iTy = nTy - 1; iTy >= 0; iTy--) {
 		for (int iTx = 0; iTx < nTx; iTx++) {
 			outF << tilingPlan.at(iTy*nTx+iTx) << " ";
 		}


### PR DESCRIPTION
* Do not generate testing tiling image in Release mode
* Load tile images when the reference image is used to calculate assembly plan
* Reverse Y-axis orientation of assembly plan output
